### PR TITLE
Extend Roact JSX documentation

### DIFF
--- a/docs/guides/roact-jsx.mdx
+++ b/docs/guides/roact-jsx.mdx
@@ -252,3 +252,23 @@ import Roact from "@rbxts/roact";
 
 const fragment = <></>;
 ```
+
+## Extending the default JSX elements
+
+By default the JSX supports all gui objects, however this may be limiting in cases where you want to manage other instances using Roact.
+Which elements are supported by JSX is determined by a global ``JSX`` namespace, to allow for more instances to be created this way you need to extend this global namespace.
+It is recommended to define this extension of the namespace in one central place for all instances.
+
+**Note the ``JSX.IntrinsicElement<T extends Instance>`` expects the type for an instance to be passed into it to allow for the properties & events to be typed correctly.**
+**Also note that, by convention, all Roblox instances should be lowercased.**
+```tsx
+declare global {
+	namespace JSX {
+		interface IntrinsicElements {
+			// Your instances into here
+			proximityprompt: JSX.IntrinsicElement<ProximityPrompt>;
+			folder: JSX.IntrinsicElement<Folder>;
+		}
+	}
+}
+```


### PR DESCRIPTION
I personally struggled with finding out this information, and think it would be quite useful to include it within the documentation.

It might need some rewording, however this is mainly to illustrate what I'm trying to add into the documentation and what use-cases it might have.
The example seems simple yet is not being explained, a developer that isn't aware of ``IntrinsicElements`` or it's purpose might be confused here - should I extend the section to quickly explain why ``IntrinsicElements`` is being extended and how it relates to ``JSX`` (Or link to an external resource that does this)?

For JSX naming conventions, perhaps instead of explaining it link to https://roblox-ts.com/docs/guides/roact-jsx/#tag-names?


More feedback needed on this. 😊