### PR TITLE
fix typo and add code snippet thing

### DIFF
--- a/docs/guides/using-existing-luau.mdx
+++ b/docs/guides/using-existing-luau.mdx
@@ -6,7 +6,7 @@ roblox-ts lets you use existing Luau scripts in your TypeScript codebase. All yo
 
 ### Creating Type Declaration Files
 
-roblox-ts will copy any non-compiled file (anything that isn't a `.ts` or `.tsx` file) into your `outDir` (out). This lets you place `.lua` files in your rootDir (src) and they will be copied into the `outDir` (out) and then synced into Roblox Studio using Rojo.
+roblox-ts will copy any non-compiled file (anything that isn't a `.ts` or `.tsx` file) into your `outDir` (out). This lets you place `.lua` files in your `rootDir` (src) and they will be copied into the `outDir` (out) and then synced into Roblox Studio using Rojo.
 
 To create a type declaration file (`.d.ts`) for this `.lua` file, simply create a file next to it using the same name.
 

--- a/docs/guides/using-existing-luau.mdx
+++ b/docs/guides/using-existing-luau.mdx
@@ -6,7 +6,7 @@ roblox-ts lets you use existing Luau scripts in your TypeScript codebase. All yo
 
 ### Creating Type Declaration Files
 
-roblox-ts will copy any non-compiled file (anything that isn't a `.ts` or `.tsx` file) into your `outDir` (out). This lets you place `.lua` files in your rootDir (src) and they will be copied into the ourDir (out) and then synced into Roblox Studio using Rojo.
+roblox-ts will copy any non-compiled file (anything that isn't a `.ts` or `.tsx` file) into your `outDir` (out). This lets you place `.lua` files in your rootDir (src) and they will be copied into the `outDir` (out) and then synced into Roblox Studio using Rojo.
 
 To create a type declaration file (`.d.ts`) for this `.lua` file, simply create a file next to it using the same name.
 


### PR DESCRIPTION
code snippet thing is to be consistent with `outDir` in the sentence before it.