### PR TITLE
- Fixed join org link?

### DIFF
--- a/docs/guides/typescript-packages.mdx
+++ b/docs/guides/typescript-packages.mdx
@@ -3,7 +3,7 @@ title: TypeScript Packages
 ---
 
 :::note
-To publish roblox-ts packages, you'll need to join the "@rbxts" npm organization. [You can do that here.](../../join-org)
+To publish roblox-ts packages, you'll need to join the "@rbxts" npm organization. [You can do that here.](../join-org)
 :::
 
 ## Getting Started


### PR DESCRIPTION
The join-org link originally linked to https://roblox-ts.com/docs/join-org instead of https://roblox-ts.com/join-org

Credit to jimmy!#0001 in the Discord for finding this issue