### PR TITLE
Download packages referenced in type definitions

### DIFF
--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -116,9 +116,9 @@ async function downloadDefinition(pkgName: string, filePath: string, isPkgTyping
 		if (ref.endsWith(".") || ref.endsWith("..")) {
 			ref += "/index";
 		}
-		const packageRef = getMatches(INPUT_IMPORT_REGEX)[0];
-		if (packageRef) {
-			jobs.push(downloadPackage(packageRef));
+		if (ref.startsWith(SCOPE)) {
+			// Cut off scope and slash, which are both added back in downloadPackage
+			jobs.push(downloadPackage(ref.substr(SCOPE.length + 1)));
 		} else {
 			const refPath = path.resolve(path.dirname(filePath), ref).substr(1) + ".d.ts";
 			jobs.push(downloadDefinition(pkgName, refPath));

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -116,8 +116,13 @@ async function downloadDefinition(pkgName: string, filePath: string, isPkgTyping
 		if (ref.endsWith(".") || ref.endsWith("..")) {
 			ref += "/index";
 		}
-		const refPath = path.resolve(path.dirname(filePath), ref).substr(1) + ".d.ts";
-		jobs.push(downloadDefinition(pkgName, refPath));
+		const packageRef = getMatches(INPUT_IMPORT_REGEX)[0];
+		if (packageRef) {
+			jobs.push(downloadPackage(packageRef));
+		} else {
+			const refPath = path.resolve(path.dirname(filePath), ref).substr(1) + ".d.ts";
+			jobs.push(downloadDefinition(pkgName, refPath));
+		}
 	}
 
 	for (const ref of getMatches(REFERENCE_TYPES_REGEX, content)) {


### PR DESCRIPTION
For example, in `@rbxts/roact-spring`:
```ts
import { Binding } from '@rbxts/roact';
import { CoreHooks } from '@rbxts/roact-hooks';
import { ControllerApi, ControllerProps } from '../Controller';
import { AnimationStyle } from '../types/common';

declare interface UseSpring {
  <T extends AnimationStyle>(hooks: CoreHooks, props: ControllerProps<T>, dependencies?: Array<unknown>): {
    [key in keyof T]: Binding<T[key]>;
  };
  <T extends ControllerProps<AnimationStyle>>(
    hooks: CoreHooks,
    props: () => T,
    dependencies?: Array<unknown>
  ): LuaTuple<[{ [key in keyof T]: Binding<T[key]> }, ControllerApi]>;
}

declare const useSpring: UseSpring;
export default useSpring;
```
The current code would not download `@rbxts/roact-hooks`, leading to broken typechecks.
(And, instead, throws errors failing to download `https://cdn.jsdelivr.net/npm/@rbxts/roact-spring@latest/src/hooks/@rbxts/roact-hooks/index.d.ts` because it interprets it as a relative reference)