### PR TITLE
Remove `Identifiers` page

### DIFF
--- a/docs/api/identifiers.mdx
+++ b/docs/api/identifiers.mdx
@@ -1,6 +1,0 @@
----
-title: Identifiers
----
-
-### `PKG_VERSION`
-This variable will be automatically replaced by the "version" string from the `package.json` file

--- a/sidebars.json
+++ b/sidebars.json
@@ -10,7 +10,6 @@
 			"label": "API",
 			"items": [
 				"api/roblox-api",
-				"api/identifiers",
 				"api/constructors",
 				"api/functions",
 				"api/utility-types"


### PR DESCRIPTION
Currently, the only identifier on the `Identifiers` page is `PKG_VERSION`, which is no longer supported. This piece of legacy pre-transformer behavior confuses new users. This PR removes the identifiers page to streamline the developer experience.

We may want to expand the documentation on the `Transformers` page to explain the replacement, as we have already documented this on the [v2.0.1 Release Notes](https://github.com/roblox-ts/roblox-ts/releases/tag/v2.0.1). I'm not sure how much responsibility we want for documenting third-party transformers versus just linking to the transformer though.

Let me know if an added callout on the `Transformers` page would be beneficial for this PR.