### PR TITLE
Remove no longer supported Simplesignals

### DIFF
--- a/docs/api/roblox-api.mdx
+++ b/docs/api/roblox-api.mdx
@@ -118,6 +118,7 @@ Instead, you should assume your inputs can be any possible value. You can verify
 Alternatively, the community has created a few networking libraries which make the experience much nicer!
 - [@rbxts/net](https://www.npmjs.com/package/@rbxts/net)
 - [@rbxts/networked-signals](https://www.npmjs.com/package/@rbxts/networked-signals)
+- [@rbxts/remo](https://www.npmjs.com/package/@rbxts/remo)
 
 ### Exceptions
 

--- a/docs/api/roblox-api.mdx
+++ b/docs/api/roblox-api.mdx
@@ -118,7 +118,6 @@ Instead, you should assume your inputs can be any possible value. You can verify
 Alternatively, the community has created a few networking libraries which make the experience much nicer!
 - [@rbxts/net](https://www.npmjs.com/package/@rbxts/net)
 - [@rbxts/networked-signals](https://www.npmjs.com/package/@rbxts/networked-signals)
-- [@rbxts/simplesignals](https://www.npmjs.com/package/@rbxts/simplesignals)
 
 ### Exceptions
 


### PR DESCRIPTION
Simplesignals is no longer maintained, introduce [@rbxts/remo](https://www.npmjs.com/package/@rbxts/remo) as an alternative. 