### PR TITLE
Redirect the user to the Engine API reference instead of listing its libraries

### DIFF
--- a/docs/api/roblox-api.mdx
+++ b/docs/api/roblox-api.mdx
@@ -34,18 +34,7 @@ coroutine.wrap(() => {
 
 <br/>
 
-You can find a list of available globals on the Roblox Developer Hub:
-- [Lua Globals](https://developer.roblox.com/api-reference/lua-docs/Lua-Globals)
-- [Roblox Globals](https://developer.roblox.com/api-reference/lua-docs/Roblox-Globals)
-- [bit32](https://developer.roblox.com/api-reference/lua-docs/bit32)
-- [coroutine](https://developer.roblox.com/api-reference/lua-docs/coroutine)
-- [debug](https://developer.roblox.com/api-reference/lua-docs/debug)
-- [math](https://developer.roblox.com/api-reference/lua-docs/math)
-- [os](https://developer.roblox.com/api-reference/lua-docs/os)
-- [string](https://developer.roblox.com/api-reference/lua-docs/string)
-- [table](https://developer.roblox.com/api-reference/lua-docs/table)
-- [task](https://developer.roblox.com/api-reference/lua-docs/task)
-- [utf8](https://developer.roblox.com/api-reference/lua-docs/utf8)
+You can find a list of available globals and libraries on the [Roblox Engine API Reference](https://create.roblox.com/docs/reference/engine).
 
 Parts of `table` and `string` have been intentionally omitted.
 


### PR DESCRIPTION
Roblox has a new creator docs website and things like globals, libraries and datatypes are more organized in the engine API reference. It seems like a better way to redirect the user to that page instead of manually listing each library.

![image](https://github.com/roblox-ts/roblox-ts.com/assets/46044567/26d0e356-2641-4777-80e2-3df22e678693)